### PR TITLE
Document base expectation constructors

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -7,7 +7,8 @@
     "fancy-app"
     "reprovide-lang"))
 (define build-deps
-  '("doc-coverage"
+  '("rackunit-doc"
+    "doc-coverage"
     "racket-doc"
     "scribble-lib"
     "scribble-text-lib"))

--- a/scribblings/data.scrbl
+++ b/scribblings/data.scrbl
@@ -1,0 +1,153 @@
+#lang scribble/manual
+
+@(require "base.rkt")
+
+@title{Expectation Constructors}
+
+The @racketmodname[expect] library provides several built-in
+@expectation-tech{expectations} and expectation constructors. The provided
+expectations are intended to supplant all the functionality of the checks
+provided by @racketmodname[rackunit].
+
+@defproc[(expect-eq? [v any/c]) expectation?]{
+ Returns an @expectation-tech{expectation} that expects a value is @racket[eq?]
+ to @racket[v], returning a single @fault-tech{fault} otherwise. The fault
+ contains an @racket[eq-attribute] and a @racket[self-attribute] for the
+ expected and actual fields, respectively.
+ @(expect-examples
+   (eval:error (expect! (expect-eq? 'foo) 'bar)))}
+
+@defproc[(expect-eqv? [v any/c]) expectation?]{
+ Returns an @expectation-tech{expectation} that expects a value is @racket[eqv?]
+ to @racket[v], returning a single @fault-tech{fault} otherwise. The fault
+ contains an @racket[eqv-attribute] and a @racket[self-attribute] for the
+ expected and actual fields, respectively.
+ @(expect-examples
+   (eval:error (expect! (expect-eqv? 'foo) 'bar)))}
+
+@defproc[(expect-equal? [v any/c]) expectation?]{
+ Returns an @expectation-tech{expectation} that expects a value is
+ @racket[equal?] to @racket[v]. Due to the recursive properties of
+ @racket[equal?], the expectation may return multiple faults identifying
+ specific sub-values that fail to meet the expectation. Most returned faults
+ contain @racket[equal-attribute] and @racket[self-attribute] values for their
+ expected and actual fields, respectively. However some sub-values may be of the
+ wrong type or contain too many items, leading to faults with
+ @racket[pred-attribute] or @racket[length-attribute]. See @racket[expect-list]
+ and the other compound data expectation constructors for details on what faults
+ may be returned for these types of values. 
+ @(expect-examples
+   (eval:error (expect! (expect-equal? '(1 2 (3 4 5) 6 7))
+                        '(1 foo (bar 4 5 extra) blah 7))))}
+
+@deftogether[
+ (@defproc[(eq-attribute? [v any/c]) boolean?]
+   @defproc[(eqv-attribute? [v any/c]) boolean?]
+   @defproc[(equal-attribute? [v any/c]) boolean?])]{
+ Predicates for the @racket[eq-attribute], @racket[eqv-attribute], and
+ @racket[equal-attribute] structures respectively. Used by @racket[expect-eq?],
+ @racket[expect-eqv?], and @racket[expect-equal?].}
+
+@deftogether[
+ (@defproc[(eq-attribute [value any/c]) eq-attribute?]
+   @defproc[(eqv-attribute [value any/c]) eqv-attribute?]
+   @defproc[(equal-attribute [value any/c]) equal-attribute?])]{
+ Constructors for the @attribute-tech{attributes} used in @fault-tech{faults}
+ returned by @racket[eq-attribute], @racket[eqv-attribute], and
+ @racket[equal-attribute] respectively. Equality attributes have descriptions
+ of the form @racket["<eq-proc> to <value>"], such as @racket["equal? to 'foo"].
+ @(expect-examples
+   (eqv-attribute 'foo)
+   (equal-attribute 12.5))}
+
+@deftogether[
+ (@defproc[(eq-attribute-value [eq-attr eq-attribute?]) any/c]
+   @defproc[(eqv-attribute-value [eqv-attr eqv-attribute?]) any/c]
+   @defproc[(equal-attribute-value [equal-attr equal-attribute?]) any/c])]{
+ Accessors for the value originally used to construct the respective attribute.
+@(expect-examples
+  (eq-attribute-value (eq-attribute 12)))}
+
+@deftogether[
+ (@defproc[(expect-not-eq? [v any/c]) expectation?]
+   @defproc[(expect-not-eqv? [v any/c]) expectation?]
+   @defproc[(expect-not-equal? [v any/c]) expectation?])]{
+ Negated variants of @racket[expect-eq?], @racket[expect-eqv?], and
+ @racket[expect-equal?] respectively. @fault-tech{Faults} returned by these
+ expectations wrap their expected @attribute-tech{attribute} in
+ @racket[not-attribute].
+ @(expect-examples
+   (eval:error (expect! (expect-not-equal? '(1 2)) '(1 foo))))}
+
+@deftogether[
+ (@defproc[(not-attribute [attr attribute?]) not-attribute?]
+   @defproc[(not-attribute? [v any/c]) boolean?]
+   @defproc[(not-attribute-negated [not-attr not-attribute?]) attribute?])]{
+ Constructor, predicate, and field accessor for the @attribute-tech{attribute}
+ returned by @racket[expect-not-eq?], @racket[expect-not-eqv?], and
+ @racket[expect-not-equal?].
+ @(expect-examples
+   (define not-foo (not-attribute (eq-attribute 'foo)))
+   not-foo
+   (not-attribute? not-foo)
+   (not-attribute-negated not-foo))}
+
+@defproc[(expect-= [x real?] [epsilon real?]) expectation?]{
+ Returns an @expectation-tech{expectation} that expects a value is a number
+ within @racket[epsilon] of @racket[x]. Returned @fault-tech{faults} have
+ instances of @racket[=-attribute] in their expected field.
+ @(expect-examples
+   (define exp10 (expect-= 10 0.01))
+   (expect! exp10 10)
+   (eval:error (expect! exp10 25))
+   (expect! exp10 10.0001))}
+
+@deftogether[
+ (@defproc[(=-attribute [x real?] [epsilon real?]) =-attribute?]
+   @defproc[(=-attribute? [v any/c]) boolean?]
+   @defproc[(=-attribute-value [=-attr =-attribute?]) real?]
+   @defproc[(=-attribute-epsilon [=-attr =-attribute?]) real?])]{
+ Constructor, predicate, and field accessors for the @attribute-tech{attribute}
+ returned by @racket[expect-=].
+ @(expect-examples
+   (define =10 (=-attribute 10 0.01))
+   =10
+   (=-attribute? =10)
+   (=-attribute-value =10)
+   (=-attribute-epsilon =10))}
+
+@deftogether[
+ (@defthing[expect-true expectation?]
+   @defthing[expect-false expectation?]
+   @defthing[expect-not-false expectation?])]{
+ @expectation-tech{Expectations} that expect a value is either @racket[#t],
+ @racket[#f], or not @racket[#f] respectively. Returned @fault-tech{faults} have
+ @racket[self-attribute] values in the expected field, except for
+ @racket[expect-not-false] which wraps a @racket[self-attribute] value in a
+ @racket[not-attribute] value.
+ @(expect-examples
+   (eval:error (expect! expect-true 'foo))
+   (eval:error (expect! expect-false 'foo))
+   (expect! expect-not-false 'foo)
+   (eval:error (expect! expect-not-false #f)))}
+
+@defproc[(expect-pred [pred predicate/c]) expectation?]{
+ Returns an @expectation-tech{expectation} that expects a value results in
+ @racket[(pred v)] returning @racket[#t]. Returned @fault-tech{faults} have
+ @racket[pred-attribute] values and @racket[self-attribute] values in their
+ expected and actual fields respectively.
+ @(expect-examples
+   (expect! (expect-pred number?) 10)
+   (eval:error (expect! (expect-pred number?) 'foo)))}
+
+@deftogether[
+ (@defproc[(pred-attribute [pred predicate/c]) pred-attribute?]
+   @defproc[(pred-attribute? [v any/c]) boolean?]
+   @defproc[(pred-attribute-value [pred-attr pred-attribute?]) predicate/c])]{
+ Constructor, predicate, and field accessor for the @attribute-tech{attribute}
+ returned by @racket[expect-pred].
+ @(expect-examples
+   (define number-attr (pred-attribute number?))
+   number-attr
+   (pred-attribute? number-attr)
+   (pred-attribute-value number-attr))}

--- a/scribblings/main.scrbl
+++ b/scribblings/main.scrbl
@@ -15,3 +15,4 @@ messages.
 @source-code-link{https://github.com/jackfirth/racket-expect}
 
 @include-section["base.scrbl"]
+@include-section["data.scrbl"]


### PR DESCRIPTION
Closes #8 

Excludes expect-list since that probably belongs with the combinators
instead of in data.rkt.