### PR TITLE
Add struct expectation forms

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -3,7 +3,8 @@
 (define scribblings
   '(("scribblings/main.scrbl" (multi-page) (library) "expect")))
 (define deps
-  '(("arguments" #:version "1.1")
+  '("syntax-classes-lib"
+    ("arguments" #:version "1.1")
     "base"
     "fancy-app"
     ("rackunit-lib" #:version "1.7")
@@ -13,4 +14,5 @@
     "doc-coverage"
     "racket-doc"
     "scribble-lib"
-    "scribble-text-lib"))
+    "scribble-text-lib"
+    "syntax-classes-lib"))

--- a/private/main.rkt
+++ b/private/main.rkt
@@ -1,11 +1,9 @@
 #lang reprovide
-;; Note that many of these modules have "no-conversion" submodules.
-;; These submodules are re-exported by convert.rkt with conversion
-;; logic attached.
 "base.rkt"
 "combinator.rkt"
 "data/main.rkt"
 "fail.rkt"
+"function.rkt"
 "logic.rkt"
 "meta.rkt"
-"function.rkt"
+"struct.rkt"

--- a/private/struct.rkt
+++ b/private/struct.rkt
@@ -5,15 +5,15 @@
 (provide define-struct-expectation
          expect-struct
          (contract-out
-          [struct (struct-field-context context)
-            ([description string?]
-             [type-id identifier?]
-             [field-id identifier?])
+          [struct (struct-accessor-context context)
+            ([description string?] [accessor-id identifier?])
             #:omit-constructor]
-          [make-struct-field-context
-           (-> identifier? identifier? struct-field-context?)]))
+          [make-struct-accessor-context
+           (-> identifier? struct-accessor-context?)]))
 
 (require (for-syntax racket/base
+                     racket/sequence
+                     racket/string
                      racket/syntax
                      syntax/parse/class/struct-id)
          syntax/parse/define
@@ -23,72 +23,83 @@
          "logic.rkt")
 
 
-(struct struct-field-context context (type-id field-id) #:transparent)
+(struct struct-accessor-context context (accessor-id) #:transparent)
 
-(define (make-struct-field-context type-id field-id)
-  (struct-field-context (format "the ~a-~a struct field"
-                                (syntax->datum type-id)
-                                (syntax->datum field-id))
-                        type-id
-                        field-id))
+(define (make-struct-accessor-context accessor-id)
+  (define msg
+    (format "the ~a struct field" (identifier-binding-symbol accessor-id)))
+  (struct-accessor-context msg accessor-id))
 
 (begin-for-syntax
-  (define (not-in-fields? known-accessors field-id accessor-id)
-    (define in-fields?
-      (ormap (λ (known) (free-identifier=? accessor-id known))
-             known-accessors))
-    (and (not in-fields?) field-id))
-  
-  (define (check-struct-field-ids struct-info field-ids accessor-ids)
-    (define known-accessors (list-ref struct-info 3))
-    (ormap (λ (f a) (not-in-fields? known-accessors f a))
-           field-ids
-           accessor-ids))
+  ;; for use in syntax-parse as: #:fail-when (check ...) "message"
+  (define (check v error-stx) (and (not v) error-stx))
 
-  (define (field->accessor field-id struct-id)
-    (format-id field-id "~a-~a" struct-id (syntax->datum field-id)
-               #:source field-id)))
+  (define (check-bound id-stx [error-stx id-stx])
+    (check (identifier-binding id-stx) error-stx))
 
-(define-simple-macro (expect-struct id:struct-id [field-id:id exp:expr] ...)
-  #:fail-when (and (not (attribute id.predicate-id)) #'id)
+  (define (check-all-bound ids-stx) (ormap check-bound (syntax->list ids-stx)))
+
+  (define (check-accessor id-stx info)
+    (define known-accessors (list-ref info 3))
+    (check (ormap (λ (known) (free-identifier=? id-stx known)) known-accessors)
+           id-stx))
+
+  (define (check-all-accessor ids-stx info)
+    (ormap (λ (id) (check-accessor id info)) (syntax->list ids-stx))))
+
+(define-simple-macro (expect-struct id:struct-id [accessor-id:id exp:expr] ...)
+  #:fail-when (check (attribute id.predicate-id) #'id)
   "predicate for struct type not known"
-  #:fail-when (and (not (identifier-binding (attribute id.predicate-id))) #'id)
-  "predicate for struct type not bound"
-  #:fail-when (and (not (attribute id.all-fields-visible?)) #'id)
-  "fields for struct type not all visible"
-  #:do [(define fields (syntax->list #'(field-id ...)))]
-  #:fail-when (check-duplicate-identifier fields) "duplicate field identifier"
-  #:with (accessor ...) (map (λ (f) (field->accessor f #'id)) fields)
-  #:fail-when (check-struct-field-ids
-               (attribute id.info) fields (syntax->list #'(accessor ...)))
-  (format "field not a member of struct type ~a" (syntax->datum #'id))
+  #:fail-when (check-bound (attribute id.predicate-id) #'id)
+  (format "predicate ~a for struct type not bound"
+          (identifier-binding-symbol #'id.predicate-id))
+  #:fail-when (check-all-bound #'(accessor-id ...))
+  "accessor not bound"
+  #:fail-when (check-duplicate-identifier (syntax->list #'(accessor-id ...)))
+  "duplicate accessor identifier"
+  #:fail-when (check-all-accessor #'(accessor-id ...) (attribute id.info))
+  (format "not known to be field accessor for struct ~a"
+          (identifier-binding-symbol #'id))
   (expect-and (expect-pred id.predicate-id)
               (expect-all
-               (expect/context (expect/proc (->expectation exp) accessor)
-                               (make-struct-field-context #'id #'field-id))
+               (expect/context (expect/proc (->expectation exp) accessor-id)
+                               (make-struct-accessor-context #'accessor-id))
                ...)))
 
 (begin-for-syntax
   (define (format-expect-id id-stx)
     (format-id id-stx "expect-~a" id-stx #:source id-stx))
+
+  (define (accessor->keyword id-stx struct-id-stx)
+    (define prefix (format "~a-" (identifier-binding-symbol struct-id-stx)))
+    (define id-str (symbol->string (identifier-binding-symbol id-stx)))
+    (define correct-format? (string-prefix? id-str prefix))
+    (and correct-format?
+         (string->keyword (substring id-str (string-length prefix)))))
   
   (define-syntax-class struct-id+expect
-    #:description "identifier or identifier pair"
+    #:attributes (id struct [struct.accessor-id 1])
+    #:description "struct identifier or identifier and struct identifier pair"
     (pattern (id:id struct:struct-id))
-    (pattern struct:struct-id #:attr id (format-expect-id #'struct)))
-  
-  (define (id->keyword id-stx)
-    (string->keyword (symbol->string (syntax->datum id-stx))))
-  
-  (define-syntax-class field-id+kw
-    #:description "identifier or identifier and keyword"
-    #:attributes (id kw [formals 1])
-    (pattern (id:id kw:keyword)
-             #:attr [formals 1] (list #'kw #'[id expect-any]))
-    (pattern id:id #:attr kw #`#,(id->keyword #'id)
-             #:attr [formals 1] (list #'kw #'[id expect-any]))))
+    (pattern struct:struct-id #:with id (format-expect-id #'struct)))
+
+  (define (syntax->list-of-lists stx) (map syntax->list (syntax->list stx))))
 
 (define-simple-macro
-  (define-struct-expectation id:struct-id+expect (id+kw:field-id+kw ...))
-  (define (id.id id+kw.formals ... ...)
-    (expect-struct id.struct [id+kw.id id+kw.id] ...)))
+  (define-struct-expectation id:struct-id+expect)
+  #:with (accessor-id ...) #'(id.struct.accessor-id ...)
+  #:do [(define keywords
+          (map (λ (id) (accessor->keyword id #'id.struct))
+               (syntax->list #'(accessor-id ...))))]
+  #:fail-when (check (andmap values keywords) #'id.struct)
+  (format "struct accessor ~a has ambiguous keyword form"
+          (identifier-binding-symbol
+           (for/first ([acc (in-syntax #'(accessor-id ...))]
+                       [kw (in-syntax keywords)]
+                       #:unless kw)
+             acc)))
+  #:with (keyword ...) keywords
+  #:with (arg ...) (generate-temporaries #'(keyword ...))
+  #:attr [formals 2] (syntax->list-of-lists #'((keyword [arg expect-any]) ...))
+  (define (id.id formals ... ...)
+    (expect-struct id.struct [accessor-id arg] ...)))

--- a/private/struct.rkt
+++ b/private/struct.rkt
@@ -1,0 +1,94 @@
+#lang racket/base
+
+(require racket/contract/base)
+
+(provide define-struct-expectation
+         expect-struct
+         (contract-out
+          [struct (struct-field-context context)
+            ([description string?]
+             [type-id identifier?]
+             [field-id identifier?])
+            #:omit-constructor]
+          [make-struct-field-context
+           (-> identifier? identifier? struct-field-context?)]))
+
+(require (for-syntax racket/base
+                     racket/syntax
+                     syntax/parse/class/struct-id)
+         syntax/parse/define
+         "base.rkt"
+         "combinator.rkt"
+         "data/main.rkt"
+         "logic.rkt")
+
+
+(struct struct-field-context context (type-id field-id) #:transparent)
+
+(define (make-struct-field-context type-id field-id)
+  (struct-field-context (format "the ~a-~a struct field"
+                                (syntax->datum type-id)
+                                (syntax->datum field-id))
+                        type-id
+                        field-id))
+
+(begin-for-syntax
+  (define (not-in-fields? known-accessors field-id accessor-id)
+    (define in-fields?
+      (ormap (λ (known) (free-identifier=? accessor-id known))
+             known-accessors))
+    (and (not in-fields?) field-id))
+  
+  (define (check-struct-field-ids struct-info field-ids accessor-ids)
+    (define known-accessors (list-ref struct-info 3))
+    (ormap (λ (f a) (not-in-fields? known-accessors f a))
+           field-ids
+           accessor-ids))
+
+  (define (field->accessor field-id struct-id)
+    (format-id field-id "~a-~a" struct-id (syntax->datum field-id)
+               #:source field-id)))
+
+(define-simple-macro (expect-struct id:struct-id [field-id:id exp:expr] ...)
+  #:fail-when (and (not (attribute id.predicate-id)) #'id)
+  "predicate for struct type not known"
+  #:fail-when (and (not (identifier-binding (attribute id.predicate-id))) #'id)
+  "predicate for struct type not bound"
+  #:fail-when (and (not (attribute id.all-fields-visible?)) #'id)
+  "fields for struct type not all visible"
+  #:do [(define fields (syntax->list #'(field-id ...)))]
+  #:fail-when (check-duplicate-identifier fields) "duplicate field identifier"
+  #:with (accessor ...) (map (λ (f) (field->accessor f #'id)) fields)
+  #:fail-when (check-struct-field-ids
+               (attribute id.info) fields (syntax->list #'(accessor ...)))
+  (format "field not a member of struct type ~a" (syntax->datum #'id))
+  (expect-and (expect-pred id.predicate-id)
+              (expect-all
+               (expect/context (expect/proc (->expectation exp) accessor)
+                               (make-struct-field-context #'id #'field-id))
+               ...)))
+
+(begin-for-syntax
+  (define (format-expect-id id-stx)
+    (format-id id-stx "expect-~a" id-stx #:source id-stx))
+  
+  (define-syntax-class struct-id+expect
+    #:description "identifier or identifier pair"
+    (pattern (id:id struct:struct-id))
+    (pattern struct:struct-id #:attr id (format-expect-id #'struct)))
+  
+  (define (id->keyword id-stx)
+    (string->keyword (symbol->string (syntax->datum id-stx))))
+  
+  (define-syntax-class field-id+kw
+    #:description "identifier or identifier and keyword"
+    #:attributes (id kw [formals 1])
+    (pattern (id:id kw:keyword)
+             #:attr [formals 1] (list #'kw #'[id expect-any]))
+    (pattern id:id #:attr kw #`#,(id->keyword #'id)
+             #:attr [formals 1] (list #'kw #'[id expect-any]))))
+
+(define-simple-macro
+  (define-struct-expectation id:struct-id+expect (id+kw:field-id+kw ...))
+  (define (id.id id+kw.formals ... ...)
+    (expect-struct id.struct [id+kw.id id+kw.id] ...)))

--- a/scribblings/main.scrbl
+++ b/scribblings/main.scrbl
@@ -21,6 +21,7 @@ messages.
 @include-section["compare.scrbl"]
 @include-section["logic.scrbl"]
 @include-section["data.scrbl"]
+@include-section["struct.scrbl"]
 @include-section["function.scrbl"]
 @include-section["combinator.scrbl"]
 @include-section["meta.scrbl"]

--- a/scribblings/struct.scrbl
+++ b/scribblings/struct.scrbl
@@ -1,0 +1,62 @@
+#lang scribble/manual
+
+@(require "base.rkt")
+
+@title{Structure Expectations}
+
+@defform[(expect-struct id [field-id expect-expr] ...)
+         #:contracts ([expect-expr any/c])]{
+ Creates an @expectation-tech{expectation} that checks a value is an instance of
+ the structure type @racket[id], then checks the value of each @racket[field-id]
+ of the struct with the corresponding @racket[expect-expr]. If any
+ @racket[expect-expr] is not an expectation, it is converted to one with
+ @racket[->expectation]. Not all fields of @racket[id] need to be provided;
+ extra fields in structures checked by the expectation do not cause any
+ @fault-tech{faults}. Fields may be provided in any order.
+
+ The @racket[id] must have a transformer binding to a @racket[struct-info?]
+ value, and that value must supply the structure type's predicate and all field
+ accessors. Faults found by the expectation in fields have a
+ @racket[struct-field-context] value added to their @context-tech{contexts}.
+
+ @(expect-examples
+   (struct fish (color weight) #:transparent)
+   (eval:error (expect! (fish 'red 5) (expect-struct fish [color 'blue]))))}
+
+@defform[(define-struct-expectation struct-maybe-id (field ...))
+         #:grammar ([struct-maybe-id struct-id (id struct-id)]
+                    [field field-id [field-kw field-id]])]{
+ Binds @racket[id] to a procedure that accepts the @racket[field-kw] keyword
+ arguments and returns an expectation with @racket[expect-struct],
+ @racket[struct-id], and each @racket[field-kw] argument paired with its
+ corresponding @racket[field-id]. If @racket[id] is not provided, it defaults to
+ @racket[expect-]@racket[struct-id]. All keyword arguments to @racket[id] are
+ optional; if not provided they default to @racket[expect-any]. If a
+ @racket[field-kw] is not provided, it defaults to the corresponding
+ @racket[field-id] converted to a keyword.
+
+ Like @racket[expect-struct], @racket[struct-id] must have a transformer binding
+ to a @racket[struct-info?] value and each @racket[field-id] must be bound to a
+ field accessor when combined with @racket[struct-id].
+
+ @(expect-examples
+   (struct fish (color weight) #:transparent)
+   (define-struct-expectation fish (color weight))
+   (eval:error (expect! (fish 'red 5) (expect-fish #:weight 20))))}
+
+@defstruct*[(struct-field-context context)
+            ([type-id identifier?] [field-id identifier?])
+            #:transparent
+            #:omit-constructor]{
+ A @context-tech{context} that indicates a fault lies in the value of a
+ @racket[field-id] field of a structure with type @racket[type-id].}
+
+@defproc[(make-struct-field-context [type-id identifier?]
+                                    [field-id identifier?])
+         struct-field-context?]{
+ Returns a @racket[struct-field-context] with a default
+ @racket[context-description] string referencing @racket[type-id] and
+ @racket[field-id].
+
+ @(expect-examples
+   (make-struct-field-context #'shape #'area))}

--- a/scribblings/struct.scrbl
+++ b/scribblings/struct.scrbl
@@ -4,59 +4,62 @@
 
 @title{Structure Expectations}
 
-@defform[(expect-struct id [field-id expect-expr] ...)
+@defform[(expect-struct id [accessor-id expect-expr] ...)
          #:contracts ([expect-expr any/c])]{
  Creates an @expectation-tech{expectation} that checks a value is an instance of
- the structure type @racket[id], then checks the value of each @racket[field-id]
- of the struct with the corresponding @racket[expect-expr]. If any
- @racket[expect-expr] is not an expectation, it is converted to one with
- @racket[->expectation]. Not all fields of @racket[id] need to be provided;
+ the structure type @racket[id], then checks the value of applying each
+ @racket[accessor-id] to the struct with the corresponding @racket[expect-expr].
+ If any @racket[expect-expr] is not an expectation, it is converted to one with
+ @racket[->expectation]. Not all accessors of @racket[id] need to be provided;
  extra fields in structures checked by the expectation do not cause any
- @fault-tech{faults}. Fields may be provided in any order.
+ @fault-tech{faults}. Accessors may be provided in any order.
 
  The @racket[id] must have a transformer binding to a @racket[struct-info?]
- value, and that value must supply the structure type's predicate and all field
- accessors. Faults found by the expectation in fields have a
- @racket[struct-field-context] value added to their @context-tech{contexts}.
+ value, and that value must supply the structure type's predicate. @bold{Parent
+  struct accessors are not currently supported}, but you may combine multiple
+ uses of @racket[expect-struct] using @racket[expect-and] to achieve the same
+ result. Faults found by the expectation in accessed fields have a
+ @racket[struct-accessor-context] value added to their
+ @context-tech{contexts}.
 
  @(expect-examples
    (struct fish (color weight) #:transparent)
-   (eval:error (expect! (fish 'red 5) (expect-struct fish [color 'blue]))))}
+   (eval:error
+    (expect! (fish 'red 5) (expect-struct fish [fish-color 'blue]))))}
 
-@defform[(define-struct-expectation struct-maybe-id (field ...))
-         #:grammar ([struct-maybe-id struct-id (id struct-id)]
-                    [field field-id [field-kw field-id]])]{
- Binds @racket[id] to a procedure that accepts the @racket[field-kw] keyword
- arguments and returns an expectation with @racket[expect-struct],
- @racket[struct-id], and each @racket[field-kw] argument paired with its
- corresponding @racket[field-id]. If @racket[id] is not provided, it defaults to
- @racket[expect-]@racket[struct-id]. All keyword arguments to @racket[id] are
- optional; if not provided they default to @racket[expect-any]. If a
- @racket[field-kw] is not provided, it defaults to the corresponding
- @racket[field-id] converted to a keyword.
+@defform[(define-struct-expectation struct-maybe-id)
+         #:grammar ([struct-maybe-id struct-id (id struct-id)])]{
+ Binds @racket[id] to a procedure that constructs
+ @expectation-tech{expectations} with @racket[expect-struct]. The bound
+ procedure accepts one keyword argument for each non-inherited field of
+ @racket[struct-id] and passes it to @racket[struct-id]. If @racket[id] is not
+ provided, it defaults to @racket[expect-]@racket[struct-id]. All keyword
+ arguments to the bound procedure are optional; if not provided they default to
+ @racket[expect-any].
 
  Like @racket[expect-struct], @racket[struct-id] must have a transformer binding
- to a @racket[struct-info?] value and each @racket[field-id] must be bound to a
- field accessor when combined with @racket[struct-id].
+ to a @racket[struct-info?], which is inspected by 
+ @racket[define-struct-expectation] to determine what accessors to generate
+ keyword arguments for. All accessors must be of the pattern
+ @racket[struct-id]-@racket[field-id] (such as fish-color) or an "ambiguous
+ keyword form" syntax error is reported. For accessors matching this pattern,
+ the corresponding keyword used by the bound procedure is the symbol
+ @racket['field-id] converted to a keyword.
 
  @(expect-examples
    (struct fish (color weight) #:transparent)
-   (define-struct-expectation fish (color weight))
+   (define-struct-expectation fish)
    (eval:error (expect! (fish 'red 5) (expect-fish #:weight 20))))}
 
-@defstruct*[(struct-field-context context)
-            ([type-id identifier?] [field-id identifier?])
-            #:transparent
-            #:omit-constructor]{
- A @context-tech{context} that indicates a fault lies in the value of a
- @racket[field-id] field of a structure with type @racket[type-id].}
+@defstruct*[(struct-accessor-context context) ([accessor-id identifier?])
+            #:transparent #:omit-constructor]{
+ A @context-tech{context} that indicates a fault lies in a struct field defined
+ by @racket[accessor-id].}
 
-@defproc[(make-struct-field-context [type-id identifier?]
-                                    [field-id identifier?])
+@defproc[(make-struct-accessor-context [accessor-id identifier?])
          struct-field-context?]{
- Returns a @racket[struct-field-context] with a default
- @racket[context-description] string referencing @racket[type-id] and
- @racket[field-id].
+ Returns a @racket[struct-accessor-context] with a default
+ @racket[context-description] string referencing @racket[accessor-id].
 
  @(expect-examples
-   (make-struct-field-context #'shape #'area))}
+   (make-struct-accessor-context #'shape-area))}

--- a/tests/struct.rkt
+++ b/tests/struct.rkt
@@ -1,0 +1,18 @@
+#lang racket/base
+
+(require expect
+         expect/rackunit
+         racket/function
+         (only-in rackunit test-case))
+
+(struct fish (color weight))
+
+(test-case "expect-struct"
+  (define red-fish-passes (expect-exp-no-faults (fish 'red 5)))
+  (check-expect (expect-struct fish [color 'red] [weight 5]) red-fish-passes)
+  (test-case "field-order"
+    (check-expect (expect-struct fish [weight 5] [color 'red]) red-fish-passes))
+  (test-case "field-optional"
+    (check-expect (expect-struct fish [color 'red]) red-fish-passes))
+  (test-case "pred"
+    (check-expect (expect-struct fish) (expect-exp-one-fault 5))))

--- a/tests/struct.rkt
+++ b/tests/struct.rkt
@@ -1,18 +1,92 @@
 #lang racket/base
 
-(require expect
+(require (for-syntax racket/base
+                     racket/list
+                     racket/struct-info)
+         expect
          expect/rackunit
          racket/function
          (only-in rackunit test-case))
 
+(struct expand-context context () #:transparent)
+(define the-expand-context (expand-context "call to expand syntax"))
+
+(define (expect-expand exp)
+  (define ((expand-thnk stx)) (expand stx))
+  (expect/context (expect/proc exp expand-thnk) the-expand-context))
+
+(define expect-syntax-exn
+  (expect-expand (expect-raise (expect-struct exn:fail:syntax))))
+
 (struct fish (color weight))
+(define red-fish-passes (expect-exp-no-faults (fish 'red 5)))
 
 (test-case "expect-struct"
-  (define red-fish-passes (expect-exp-no-faults (fish 'red 5)))
-  (check-expect (expect-struct fish [color 'red] [weight 5]) red-fish-passes)
-  (test-case "field-order"
-    (check-expect (expect-struct fish [weight 5] [color 'red]) red-fish-passes))
-  (test-case "field-optional"
-    (check-expect (expect-struct fish [color 'red]) red-fish-passes))
-  (test-case "pred"
-    (check-expect (expect-struct fish) (expect-exp-one-fault 5))))
+  (check-expect (expect-struct fish [fish-color 'red] [fish-weight 5])
+                red-fish-passes)
+  (test-case "accessor-order"
+    (check-expect (expect-struct fish [fish-weight 5] [fish-color 'red])
+                  red-fish-passes))
+  (test-case "accessor-optional"
+    (check-expect (expect-struct fish [fish-color 'red]) red-fish-passes))
+  (test-case "predicate"
+    (check-expect (expect-struct fish) (expect-exp-one-fault 5)))
+  (test-case "syntax"
+    (test-case "accessor-unbound"
+      (check-expect #'(let ()
+                        (struct fish (color weight))
+                        (expect-struct fish [unbound 4]))
+                    expect-syntax-exn))
+    (test-case "non-accessor-binding"
+      (check-expect #'(let ()
+                        (define legs #f)
+                        (expect-struct fish [legs 4]))
+                    expect-syntax-exn))
+    (test-case "duplicate"
+      (check-expect #'(let ()
+                        (struct fish (color weight))
+                        (expect-struct fish
+                                       [fish-color 'red] [fish-color 'red]))
+                    expect-syntax-exn))
+    (test-case "predicate-unknown"
+      (check-expect #'(let ()
+                        (struct fish (color weight))
+                        (define-syntax fish/no-pred
+                          (list-set (extract-struct-info
+                                     (syntax-local-value #'fish))
+                                    2 #f))
+                        (expect-struct fish/no-pred))
+                    expect-syntax-exn))
+    (test-case "predicate-unbound"
+      (check-expect #'(let ()
+                        (struct fish (color weight))
+                        (define-syntax fish/bad-pred
+                          (list-set (extract-struct-info
+                                     (syntax-local-value #'fish))
+                                    2 #'unbound))
+                        (expect-struct fish/bad-pred))
+                    expect-syntax-exn))
+    (test-case "parent-field-disallowed"
+      (define stx
+        #'(let ()
+            (struct parent (a))
+            (struct child (b))
+            (expect-struct child [parent-a 'foo])))
+      (check-expect stx expect-syntax-exn))))
+
+(test-case "define-struct-expectation"
+  (define-struct-expectation fish)
+  (check-expect (expect-fish #:color 'red) red-fish-passes)
+  (test-case "alternate-name"
+    (define-struct-expectation (expfish fish))
+    (check-expect (expfish #:color 'red) red-fish-passes))
+  (test-case "keyword-ambiguous"
+    (define stx
+      #'(let ()
+          (struct fish (color weight))
+          (define-syntax fish/ambiguous-kw-accessor
+            (list-set (extract-struct-info
+                       (syntax-local-value #'fish))
+                      3 (list #'fish-color #'get-weight)))
+          (define-struct-expectation fish/ambiguous-kw-accessor)))
+    (check-expect stx expect-syntax-exn)))


### PR DESCRIPTION
Closes #20 

Includes internal implementations of `expect-expand` and `expect-syntax-exn` for use in testing error conditions of the struct macros. They're not robust enough to be exposed and documented yet, but they should be built on for #30.