### PR TITLE
Add syntax expectations and utilities needed by them

### DIFF
--- a/private/combinator.rkt
+++ b/private/combinator.rkt
@@ -7,7 +7,10 @@
   [expect/context (-> expectation? context? expectation?)]
   [expect/dependent (-> (-> any/c expectation?) expectation?)]
   [expect/proc (-> expectation? (-> any/c any/c) expectation?)]
-  [expect/singular (-> (-> any/c (or/c fault? #f)) expectation?)]))
+  [expect/singular (-> (-> any/c (or/c fault? #f)) expectation?)]
+  [expect/around (-> expectation?
+                     (-> (-> (listof fault?)) (listof fault?))
+                     expectation?)]))
 
 (require arguments
          fancy-app
@@ -40,3 +43,6 @@
 (define (expect/singular maybe-fault-func)
   (expectation
    (λ (v) (define flt (maybe-fault-func v)) (if flt (list flt) (list)))))
+
+(define (expect/around exp f)
+  (expectation (λ (v) (f (thunk (expectation-apply exp v))))))

--- a/private/function.rkt
+++ b/private/function.rkt
@@ -99,10 +99,7 @@
 
 (struct apply-context context (proc) #:transparent)
 (define (make-apply-context proc)
-  (define n (object-name proc))
-  (apply-context (format "application to ~a"
-                         (if n (format "procedure ~a" n) (~v proc)))
-                 proc))
+  (apply-context (format "application to ~v" proc) proc))
 
 (define (expect-proc-arity arity-exp)
   (expect/context (expect/proc arity-exp procedure-arity) the-arity-context))

--- a/private/main.rkt
+++ b/private/main.rkt
@@ -8,3 +8,4 @@
 "meta.rkt"
 "regexp.rkt"
 "struct.rkt"
+"syntax.rkt"

--- a/private/regexp.rkt
+++ b/private/regexp.rkt
@@ -7,11 +7,14 @@
   [expect-regexp-match
    (->* (regexp?)
         ((or/c (listof (or/c string? bytes? #f expectation?))
-               #f
                expectation?))
         expectation?)]
   [struct (regexp-match-context context)
-    ([description string?] [regexp regexp?])]))
+    ([description string?] [regexp regexp?]) #:omit-constructor]
+  [make-regexp-match-context (-> regexp? regexp-match-context?)]
+  [struct (regexp-match-attribute attribute)
+    ([description string?] [regexp regexp?]) #:omit-constructor]
+  [make-regexp-match-attribute (-> regexp? regexp-match-attribute?)]))
 
 (require fancy-app
          "base.rkt"
@@ -20,16 +23,31 @@
          "logic.rkt")
 
 
-(define (expect-regexp-match pattern [result-exp expect-not-false])
+(define (expect-regexp-match pattern [result-exp expect-any])
   (expect-and (expect-disjoin string? bytes? path? input-port?)
+              (expect-regexp-match? pattern)
               (expect/context (expect/proc (->expectation result-exp)
                                            (regexp-match pattern _))
                               (make-regexp-match-context pattern))))
+
+;; not provided because calling expect-regexp-match with a default result-exp
+;; is equivalent to calling this
+(define (expect-regexp-match? pattern)
+  (expect/singular
+   (λ (str)
+     (and (not (regexp-match? pattern str))
+          (fault #:summary "a value matching a regexp"
+                 #:expected (make-regexp-match-attribute pattern)
+                 #:actual (make-self-attribute str))))))
 
 (struct regexp-match-context context (regexp) #:transparent)
 (define (make-regexp-match-context regexp)
   (regexp-match-context (format "the results of matching ~v" regexp)
                         regexp))
+
+(struct regexp-match-attribute attribute (regexp) #:transparent)
+(define (make-regexp-match-attribute regexp)
+  (regexp-match-attribute (format "string matching regexp ~v" regexp) regexp))
 
 (module+ main
   (require "fail.rkt")

--- a/private/struct.rkt
+++ b/private/struct.rkt
@@ -51,10 +51,10 @@
   #:fail-when (check (attribute id.predicate-id) #'id)
   "predicate for struct type not known"
   #:fail-when (check-bound (attribute id.predicate-id) #'id)
-  (format "predicate ~a for struct type not bound"
+  (format "predicate ~a for struct type undefined"
           (identifier-binding-symbol #'id.predicate-id))
   #:fail-when (check-all-bound #'(accessor-id ...))
-  "accessor not bound"
+  "accessor undefined"
   #:fail-when (check-duplicate-identifier (syntax->list #'(accessor-id ...)))
   "duplicate accessor identifier"
   #:fail-when (check-all-accessor #'(accessor-id ...) (attribute id.info))

--- a/private/syntax.rkt
+++ b/private/syntax.rkt
@@ -1,0 +1,57 @@
+#lang racket/base
+
+(require racket/contract/base)
+
+(provide
+ (contract-out
+  [expect-syntax (-> any/c expectation?)]
+  [expect-expand (->* (expectation?) (#:namespace namespace?) expectation?)]
+  [expect-expand-once (->* (expectation?)
+                           (#:namespace namespace?)
+                           expectation?)]
+  [expect-syntax-exn (->* ((or/c string? regexp? expectation?))
+                          (#:namespace namespace?)
+                          expectation?)]
+  [struct (datum-context context) ([description string?]) #:omit-constructor]
+  [the-datum-context datum-context?]))
+
+(require arguments
+         racket/function
+         "base.rkt"
+         "combinator.rkt"
+         "data/convert-base.rkt"
+         "function.rkt"
+         "logic.rkt"
+         "regexp.rkt"
+         "struct.rkt")
+
+
+(struct datum-context context () #:transparent)
+(define the-datum-context (datum-context "the syntax's datum"))
+
+(define (expect-syntax exp)
+  (expect-and (expect-pred syntax?)
+              (expect/context (expect/proc (->expectation exp) syntax->datum)
+                              the-datum-context)))
+
+(define (expect-expand* f exp ns)
+  (define (around thnk) (parameterize ([current-namespace ns]) (thnk)))
+  (expect-and (expect-pred syntax?)
+              (expect/proc (expect/around (expect-apply f exp) around)
+                           arguments)))
+
+(define (expect-expand exp #:namespace [ns (current-namespace)])
+  (expect-expand* expand exp ns))
+
+(define (expect-expand-once exp #:namespace [ns (current-namespace)])
+  (expect-expand* expand-once exp ns))
+
+(define (expect-syntax-exn [msg-exp expect-any]
+                           #:namespace [ns (current-namespace)])
+  (define msg-exp*
+    (if (regexp? msg-exp)
+        (expect-regexp-match msg-exp)
+        (->expectation msg-exp)))
+  (define raise-exp
+    (expect-raise (expect-struct exn:fail:syntax [exn-message msg-exp*])))
+  (expect-expand raise-exp #:namespace ns))

--- a/private/syntax.rkt
+++ b/private/syntax.rkt
@@ -9,8 +9,9 @@
   [expect-expand-once (->* (expectation?)
                            (#:namespace namespace?)
                            expectation?)]
-  [expect-syntax-exn (->* ((or/c string? regexp? expectation?))
-                          (#:namespace namespace?)
+  [expect-syntax-exn (->* ()
+                          ((or/c string? regexp? expectation?)
+                           #:namespace namespace?)
                           expectation?)]
   [struct (datum-context context) ([description string?]) #:omit-constructor]
   [the-datum-context datum-context?]))

--- a/scribblings/combinator.scrbl
+++ b/scribblings/combinator.scrbl
@@ -14,6 +14,7 @@ expectations out of simple ones while preserving error message quality.
  except that any @fault-tech{faults} returned have @racket[ctxt] as an
  additional @context-tech{context}. The extra context is added to the beginning
  of each fault's list of contexts, not the end.
+ 
  @(expect-examples
    (struct test-context context () #:transparent)
    (define test-exp (expect/context (expect-eq? 'foo) (test-context "test")))
@@ -23,6 +24,7 @@ expectations out of simple ones while preserving error message quality.
  Returns an @expectation-tech{expectation} that behaves like @racket[exp] except
  that input values are passed to @racket[proc] and the result is given to
  @racket[exp].
+ 
  @(expect-examples
    (define first-foo (expect/proc (expect-eq? 'foo) first))
    (expect! '(foo bar) first-foo)
@@ -34,6 +36,7 @@ expectations out of simple ones while preserving error message quality.
  @racket[exp-proc]. This is useful when the exact set of faults that a value
  could have depends on the shape of the value, such as in the case of
  @racket[expect-list] (which uses @racket[expect/dependent] under the hood).
+
  @(expect-examples
    (define (last-string-expectation vs)
      (expect-list-ref (expect-pred string?) (sub1 (length vs))))
@@ -49,6 +52,7 @@ expectations out of simple ones while preserving error message quality.
  returns @racket[#f]. This is useful when an expectation could logically only
  return a single fault at most, removing the boilerplate of returning either a
  singular list or an empty list.
+
  @(expect-examples
    (struct single-digit-attribute attribute () #:transparent)
    (define (single-digit-fault v)
@@ -59,3 +63,24 @@ expectations out of simple ones while preserving error message quality.
    (define expect-single-digit (expect/singular single-digit-fault))
    (expect! 5 expect-single-digit)
    (eval:error (expect! 123 expect-single-digit)))}
+
+@defproc[(expect/around [exp expectation?]
+                        [around-proc (-> (-> (listof fault?)) (listof fault?))])
+         expectation?]{
+ Returns an @expectation-tech{expectation} that wraps every call to @racket[exp]
+ with @racket[around-proc]. The argument to @racket[around-proc] is a thunk that
+ returns the @fault-tech{faults} found by @racket[exp] in the input of the
+ returned expectation, and the return value of @racket[around-proc] is used as
+ the faults found by the returned expectation. This allows customizing the
+ dynamic extent of an expectation, and in particular is useful for expectations
+ that need to @racket[parameterize] their application.
+
+ @(expect-examples
+   (define (log-num-faults thnk)
+     (define fs (thnk))
+     (printf "found ~v faults\n" (length fs))
+     fs)
+   (define exp-123/log
+     (expect/around (expect-equal? '(1 2 3)) log-num-faults))
+   (expect! '(1 2 3) exp-123/log)
+   (eval:error (expect! '(1 a b) exp-123/log)))}

--- a/scribblings/main.scrbl
+++ b/scribblings/main.scrbl
@@ -24,6 +24,7 @@ messages.
 @include-section["text.scrbl"]
 @include-section["struct.scrbl"]
 @include-section["function.scrbl"]
+@include-section["syntax.scrbl"]
 @include-section["combinator.scrbl"]
 @include-section["meta.scrbl"]
 @include-section["convert.scrbl"]

--- a/scribblings/struct.scrbl
+++ b/scribblings/struct.scrbl
@@ -15,11 +15,9 @@
  @fault-tech{faults}. Accessors may be provided in any order.
 
  The @racket[id] must have a transformer binding to a @racket[struct-info?]
- value, and that value must supply the structure type's predicate. @bold{Parent
-  struct accessors are not currently supported}, but you may combine multiple
- uses of @racket[expect-struct] using @racket[expect-and] to achieve the same
- result. Faults found by the expectation in accessed fields have a
- @racket[struct-accessor-context] value added to their
+ value, and that value must supply the structure type's predicate. Accessors of
+ the struct's supertypes are allowed. Faults found by the expectation in
+ accessed fields have a @racket[struct-accessor-context] value added to their
  @context-tech{contexts}.
 
  @(expect-examples

--- a/scribblings/syntax.scrbl
+++ b/scribblings/syntax.scrbl
@@ -1,0 +1,58 @@
+#lang scribble/manual
+
+@(require "base.rkt")
+
+@title{Macro and Syntax Expectations}
+
+@defproc[(expect-syntax [datum-exp any/c]) expectation?]{
+ Returns an @expectation-tech{expectation} that expects a syntax object whose
+ datum is then checked against @racket[datum-exp]. If @racket[datum-exp] is not
+ an expectation, it is converted to one with @racket[->expectation].}
+
+@defproc[(expect-expand [exp expectation?]
+                        [#:namespace ns namespace? (current-namespace)])
+         expectation?]{
+ Returns an @expectation-tech{expectation} that expects a syntax object object
+ @racket[stx], then a thunk that evaluates @racket[(expand stx)] is created and
+ checked against @racket[exp]. The call to @racket[expand] is made with
+ @racket[current-namespace] parameterized to @racket[ns]. Combine this with
+ @racket[expect-raise] to test that a specific syntax error is made, or  combine
+ with @racket[expect-return] to test properties of the resulting fully expanded
+ syntax. See also @racket[expect-syntax-exn].
+
+ @(expect-examples
+   (define success #f)
+   (define-syntax-rule (foo (id v) ...) success)
+   (expect! #'(foo (a 1) (b 2))
+            (expect-expand (expect-return (expect-syntax 'success))))
+   (eval:error (expect! #'(foo a) (expect-expand expect-not-raise))))}
+
+@defproc[(expect-expand-once [exp expectation?]
+                             [#:namespace ns namespace? (current-namespace)])
+         expectation?]{
+ Like @racket[expect-expand], but calls @racket[expand-once] on the input syntax
+ object instead of @racket[expand].}
+
+@defproc[(expect-syntax-exn [msg-exp (or/c string? regexp? expectation?)]
+                            [#:namespace ns namespace? (current-namespace)])
+         expectation?]{
+ Returns an @expectation-tech{expectation} that expects a syntax object and
+ expects that expanding that syntax object raises an @racket[exn:fail:syntax]
+ value whose message is checked against @racket[msg-exp]. The syntax object is
+ expanded with @racket[current-namespace] parameterized to @racket[ns]. If
+ @racket[msg-exp] is a regexp, it is converted to an expectation with
+ @racket[expect-regexp-match]. Otherwise, it is converted with
+ @racket[->expectation]. This procedure is essentially sugar over combining
+ @racket[expect-expand], @racket[expect-raise], @racket[expect-struct], and
+ @racket[expect-regexp-match] manually.
+
+ @(expect-examples
+   (expect! #'(let ([a 1] [a 2]) (void)) (expect-syntax-exn #rx"duplicate")))}
+
+@section{Syntax Expectation Contexts}
+
+@deftogether[
+ (@defstruct*[(datum-context context) () #:transparent #:omit-constructor]
+   @defthing[the-datum-context datum-context?])]{
+ A @context-tech{context} that represents the results of calling
+ @racket[syntax->datum] on a syntax object.}

--- a/scribblings/syntax.scrbl
+++ b/scribblings/syntax.scrbl
@@ -33,8 +33,9 @@
  Like @racket[expect-expand], but calls @racket[expand-once] on the input syntax
  object instead of @racket[expand].}
 
-@defproc[(expect-syntax-exn [msg-exp (or/c string? regexp? expectation?)]
-                            [#:namespace ns namespace? (current-namespace)])
+@defproc[(expect-syntax-exn
+          [msg-exp (or/c string? regexp? expectation?) expect-any]
+          [#:namespace ns namespace? (current-namespace)])
          expectation?]{
  Returns an @expectation-tech{expectation} that expects a syntax object and
  expects that expanding that syntax object raises an @racket[exn:fail:syntax]

--- a/scribblings/text.scrbl
+++ b/scribblings/text.scrbl
@@ -7,7 +7,6 @@
 @defproc[(expect-regexp-match
           [pattern regexp?]
           [result-exp (or/c (listof (or/c string? bytes? #f expectation?))
-                            #f
                             expectation?)
            expect-not-false])
          expectation?]{
@@ -17,9 +16,7 @@
  with @racket[result-exp]. Using the default for @racket[result-exp] checks
  that @racket[pattern] matches the input value and ignores the result of the
  match. If @racket[result-exp] is not an expectation, it is converted to one
- with @racket[->expectation]. All @fault-tech{faults} returned by
- @racket[result-exp] have a @racket[regexp-match-context] value added to their
- @context-tech{contexts}.
+ with @racket[->expectation].
 
  @(expect-examples
    (expect! "This is some message" (expect-regexp-match #rx"some"))
@@ -27,7 +24,19 @@
    (eval:error (expect! "12x4x6" (expect-regexp-match #rx"x." '("x6")))))}
 
 
-@defstruct*[(regexp-match-context context) ([regexp regexp?])
-            #:transparent #:omit-constructor]{
- A @context-tech{context} that indicates a @fault-tech{fault} occurred in the
- result of calling @racket[regexp-match] with @racket[regexp].}
+@deftogether[
+ (@defstruct*[(regexp-match-context context) ([regexp regexp?])
+              #:transparent #:omit-constructor]
+   @defproc[(make-regexp-match-context [regexp regexp?])
+            regexp-match-context?])]{
+ A @context-tech{context} and its constructor that indicates a
+ @fault-tech{fault} occurred in the result of calling @racket[regexp-match] with
+ @racket[regexp].}
+
+@deftogether[
+ (@defstruct*[(regexp-match-attribute attribute) ([regexp regexp?])
+              #:transparent #:omit-constructor]
+   @defproc[(make-regexp-match-attribute [regexp regexp?])
+            regexp-match-attribute?])]{
+ An @attribute-tech{attribute} and its constructor that refers to whether or not
+ a value matches @racket[regexp].}

--- a/tests/regexp.rkt
+++ b/tests/regexp.rkt
@@ -9,4 +9,3 @@
               (expect-regexp-match #rx"x." (list (expect-equal? "x4"))))
 (check-expect "12x4x6" (expect-regexp-match #rx"x." (expect-list "x4")))
 (check-expect (expect-regexp-match #rx"y.") (expect-exp-one-fault "12x4x6"))
-(check-expect "12x4x6" (expect-regexp-match #rx"y." #f))

--- a/tests/syntax.rkt
+++ b/tests/syntax.rkt
@@ -1,0 +1,99 @@
+#lang racket/base
+
+(require expect
+         expect/rackunit
+         racket/string
+         syntax/parse/define
+         (only-in rackunit test-begin test-case))
+
+
+(define-simple-macro (test-begin/expect subject:expr exp:expr ...)
+  (test-begin
+    (define s subject)
+    (check-expect s exp) ...))
+
+(define-simple-macro (test-case/expect name:str subject:expr exp:expr ...)
+  (test-case name
+    (define s subject)
+    (check-expect s exp) ...))
+
+(test-case/expect "expect-syntax"
+  (expect-syntax 'here)
+  (expect-exp-faults #'here (list))
+  (expect-exp-faults
+   'here (list (expect-fault #:expected (expect-pred pred-attribute?))))
+  (expect-exp-faults
+   #'there (list (expect-fault #:expected (expect-pred equal-attribute?)
+                               #:contexts (list the-datum-context)))))
+
+(define-syntax-rule (foo ([id v] ...)) (bar v ...))
+(define-syntax-rule (bar v) add1)
+(define-namespace-anchor here)
+(define here-ns (namespace-anchor->namespace here))
+
+(define expect-expand-raise-any-fault
+  (expect-fault #:expected the-none-attribute
+                #:contexts (list (make-apply-context expand)
+                                 the-raise-context)))
+
+(define expect-expand-once-raise-any-fault
+  (expect-fault #:expected the-none-attribute
+                #:contexts (list (make-apply-context expand-once)
+                                 the-raise-context)))
+
+(test-case "expect-expand"
+  (test-case/expect "not-raise"
+    (expect-expand expect-not-raise)
+    (expect-exp-faults #'(void) (list))
+    (expect-exp-faults #'(let ([a 1]) (let (1) (void)))
+                       (list expect-expand-raise-any-fault)))
+  (test-case/expect "#:namespace"
+    (expect-expand (expect-return (expect-syntax 'add1)) #:namespace here-ns)
+    (expect-exp-faults #'(foo ([a 1])) (list))
+    (expect-exp-faults
+     #'sub1
+     (list (expect-fault #:expected (expect-pred equal-attribute?)
+                         #:actual (make-self-attribute 'sub1)
+                         #:contexts (list (make-apply-context expand)
+                                          the-return-context
+                                          expect-any
+                                          the-datum-context))))
+    (expect-exp-faults #'(foo ([a 1] [b 2]))
+                       (list expect-expand-raise-any-fault))))
+
+(test-case "expect-expand-once"
+  (test-case/expect "not-raise"
+    (expect-expand-once expect-not-raise)
+    (expect-exp-faults #'(void) (list))
+    (expect-exp-faults #'(let ([a 1]) (let (1) (void))) (list))
+    (expect-exp-faults #'(let (1) (void))
+                       (list expect-expand-once-raise-any-fault)))
+  (test-case/expect "#:namespace"
+    (expect-expand-once (expect-return (expect-syntax '(bar 1 2)))
+                        #:namespace here-ns)
+    (expect-exp-faults #'(foo ([a 1] [b 2])) (list))
+    (expect-exp-faults #'(foo (1)) (list expect-expand-once-raise-any-fault))))
+
+(define (contains-let? str) (string-contains? str "let"))
+
+(test-case "expect-syntax-exn"
+  (test-begin/expect
+    (expect-syntax-exn (expect-pred contains-let?))
+    (expect-exp-faults #'(let (1) (void)) (list))
+    (expect-exp-faults #'(lambda) (list (expect-fault))))
+  (test-case/expect "default"
+    (expect-syntax-exn)
+    (expect-exp-faults #'(let (1) (void)) (list))
+    (expect-exp-faults #'(let ([a 1]) (void)) (list (expect-fault))))
+  (test-case/expect "regexp"
+    (expect-syntax-exn #rx"lamb")
+    (expect-exp-faults #'(lambda) (list))
+    (expect-exp-faults #'(let (1) (void)) (list (expect-fault))))
+  (test-case/expect "#:namespace"
+    (expect-syntax-exn #:namespace here-ns)
+    (expect-exp-faults
+     #'(foo ([v 1]))
+     (list (expect-fault #:expected the-any-attribute
+                         #:actual the-none-attribute
+                         #:contexts (list (make-apply-context expand)
+                                          the-raise-context))))))


### PR DESCRIPTION
Closes #30 
Closes #79 
Closes #78 
Closes #77 (technically closed by a commit to master that was supposed to be part of this PR and was accidentally committed on master instead)

The cornerstone here is `expect-expand`, which is like `expect-call` but creates a thunk that calls `expand` on an input syntax object instead.