### PR TITLE
Add expectation exceptions

### DIFF
--- a/scribblings/function.scrbl
+++ b/scribblings/function.scrbl
@@ -11,7 +11,7 @@
  procedure call and with @racket[expect-raise] or @racket[expect-not-raise] to
  check how the procedure call behaves with respect to raised errors. The
  expected procedure's arity is checked to ensure it can be called with
- @racket[args].
+ @racket[args]. See also @racket[expect-call-exn].
  @(expect-examples
    (define exp-addition (expect-call (arguments 3 8) (expect-return 11)))
    (expect! + exp-addition)
@@ -25,7 +25,7 @@
  thunk wrapping a call to @racket[f] with the arguments. Like
  @racket[expect-call], to check the return value or raised values use
  @racket[expect-return], @racket[expect-raise], or @racket[expect-not-raise] for
- @racket[call-exp].
+ @racket[call-exp]. See also @racket[expect-apply-exn].
  @(expect-examples
    (define exp-add1=10 (expect-apply add1 (expect-return 10)))
    (expect! (arguments 9) exp-add1=10)
@@ -76,6 +76,36 @@
    (define (not-a-thunk unexpected-arg)
      'foo)
    (eval:error (expect! not-a-thunk expect-not-raise)))}
+
+@defproc[(expect-exn [msg-exp (or/c string? regexp? expectation?) expect-any])
+         expectation?]{
+ Returns an @expectation-tech{expectation} that expects an @racket[exn] value or
+ a subtype. The input exception's message is then checked against
+ @racket[msg-exp]. If @racket[msg-exp] is a regexp, it is converted to an
+ expectation with @racket[(expect-regexp-match msg-exp)]; otherwise it is
+ converted with @racket[->expectation]. See also @racket[expect-call-exn] and
+ @racket[expect-apply-exn].
+
+ @(expect-examples
+   (define foo-exn (make-exn "foo exception" (current-continuation-marks)))
+   (expect! foo-exn (expect-exn #rx"foo"))
+   (expect! foo-exn (expect-exn "foo exception"))
+   (eval:error (expect! foo-exn (expect-exn "foo")))
+   (eval:error (expect! 'not-an-exn (expect-exn))))}
+
+@defproc[(expect-call-exn
+          [args arguments?]
+          [msg-exp (or/c string? regexp? expectation?) expect-any])
+         expectation?]{
+ Convenient shorthand for
+ @racket[(expect-call args (expect-raise (expect-exn msg-exp)))].}
+
+@defproc[(expect-apply-exn
+          [f procedure?]
+          [msg-exp (or/c string? regexp? expectation?) expect-any])
+         expectation?]{
+ Convenient shorthand for
+ @racket[(expect-apply args (expect-raise (expect-exn msg-exp)))].}
 
 @section{Procedure Context Structures}
 

--- a/tests/function.rkt
+++ b/tests/function.rkt
@@ -1,8 +1,11 @@
 #lang racket/base
 
-(require expect
+(require arguments
+         expect
          expect/rackunit
          racket/function
+         racket/string
+         (only-in rackunit test-case)
          "function-util.rkt")
 
 (define (expect-attribute descr)
@@ -27,3 +30,59 @@
 (check-expect (expect-return 'foo)
               (expect-expects identity "arity accepting 0 arguments"))
 (check-expect (expect-return 'foo) (expect-expects raise-foo "nothing"))
+
+(define exp-exn-message-context
+  (expect-struct struct-accessor-context
+                 [struct-accessor-context-accessor-id
+                  (expect-syntax 'exn-message)]))
+
+(define (exp-exn-rx-fault pattern ctxt)
+  (define ctxt-list (list ctxt the-raise-context exp-exn-message-context))
+  (expect-fault #:expected (make-regexp-match-attribute pattern)
+                #:actual (expect-pred self-attribute?)
+                #:contexts ctxt-list))
+
+(test-case "expect-exn"
+  (define foo-exn (make-exn "foo exception" (current-continuation-marks)))
+  (define (starts-with-foo? str) (string-prefix? str "foo"))
+  (define (starts-with-bar? str) (string-prefix? str "bar"))
+
+  (test-case "passing-input"
+    (define foo-exn-passes (expect-exp-faults foo-exn))
+    (check-expect (expect-exn "foo exception") foo-exn-passes)
+    (check-expect (expect-exn #rx"foo") foo-exn-passes)
+    (check-expect (expect-exn (expect-pred starts-with-foo?)) foo-exn-passes))
+
+  (test-case "failing-input"
+    (define (exp-foo-exn-expects attr)
+      (define fault-exp
+        (expect-fault #:expected attr
+                      #:actual (make-self-attribute "foo exception")
+                      #:contexts (list exp-exn-message-context)))
+      (expect-exp-faults foo-exn fault-exp))
+
+    (test-case "string"
+      (define bar-exn-attr (equal-attribute "bar exception"))
+      (check-expect (expect-exn "bar exception")
+                    (exp-foo-exn-expects bar-exn-attr)))
+    (test-case "regexp"
+      (define foooo-attr (make-regexp-match-attribute #rx"foooo"))
+      (check-expect (expect-exn #rx"foooo") (exp-foo-exn-expects foooo-attr)))
+    (test-case "expectation"
+      (define starts-with-bar-attr (pred-attribute starts-with-bar?))
+      (check-expect (expect-exn (expect-pred starts-with-bar?))
+                    (exp-foo-exn-expects starts-with-bar-attr)))))
+
+(define foo-args (arguments 'foo))
+
+(test-case "expect-call-exn"
+  (check-expect (expect-call-exn foo-args #rx"foo") (expect-exp-faults error))
+  (define exp (exp-exn-rx-fault #rx"nonsense" (make-call-context foo-args)))
+  (check-expect (expect-call-exn foo-args #rx"nonsense")
+                (expect-exp-faults error exp)))
+
+(test-case "expect-apply-exn"
+  (check-expect (expect-apply-exn error #rx"foo") (expect-exp-faults foo-args))
+  (define exp (exp-exn-rx-fault #rx"nonsense" (make-apply-context error)))
+  (check-expect (expect-apply-exn error #rx"nonsense")
+                (expect-exp-faults foo-args exp)))

--- a/tests/function.rkt
+++ b/tests/function.rkt
@@ -71,7 +71,15 @@
     (test-case "expectation"
       (define starts-with-bar-attr (pred-attribute starts-with-bar?))
       (check-expect (expect-exn (expect-pred starts-with-bar?))
-                    (exp-foo-exn-expects starts-with-bar-attr)))))
+                    (exp-foo-exn-expects starts-with-bar-attr))))
+
+  (test-case "default"
+    (check-expect (expect-exn) (expect-exp-faults foo-exn))
+    (define fault-exp
+      (expect-fault #:actual (make-self-attribute 'not-an-exn)
+                    #:expected (pred-attribute exn?)
+                    #:contexts (list)))
+    (check-expect (expect-exn) (expect-exp-faults 'not-an-exn fault-exp))))
 
 (define foo-args (arguments 'foo))
 
@@ -79,10 +87,14 @@
   (check-expect (expect-call-exn foo-args #rx"foo") (expect-exp-faults error))
   (define exp (exp-exn-rx-fault #rx"nonsense" (make-call-context foo-args)))
   (check-expect (expect-call-exn foo-args #rx"nonsense")
-                (expect-exp-faults error exp)))
+                (expect-exp-faults error exp))
+  (test-case "default"
+    (check-expect (expect-call-exn foo-args) (expect-exp-faults error))))
 
 (test-case "expect-apply-exn"
   (check-expect (expect-apply-exn error #rx"foo") (expect-exp-faults foo-args))
   (define exp (exp-exn-rx-fault #rx"nonsense" (make-apply-context error)))
   (check-expect (expect-apply-exn error #rx"nonsense")
-                (expect-exp-faults foo-args exp)))
+                (expect-exp-faults foo-args exp))
+  (test-case "default"
+    (check-expect (expect-apply-exn error) (expect-exp-faults foo-args))))


### PR DESCRIPTION
Closes #84, but with a slightly expanded API:

- The `expect-exn` expectation expects an `exn` struct with a message matching a string, regexp, or expectation
- The `expect-call-exn` expectation combines `expect-call`, `expect-raise`, and `expect-exn`
- The `expect-apply-exn` expectation combines `expect-apply`, `expect-raise`, and `expect-exn`